### PR TITLE
Fix/impossibilité de créer un voyage depuis javafx et visualiser activites

### DIFF
--- a/frontend/src/main/java/com/treep/frontend/controller/DashboardController.java
+++ b/frontend/src/main/java/com/treep/frontend/controller/DashboardController.java
@@ -40,6 +40,7 @@ public class DashboardController {
     public void onSubmit() {
         try {
             List<Activity> activityList = new ArrayList<>();
+            String dateDebut = (dateInput.getValue() != null) ? dateInput.getValue().toString() : "2025-01-01";
             if (activitiesInput.getText() != null && !activitiesInput.getText().isBlank()) {
                 String[] rawActivities = activitiesInput.getText().split(",");
                 for (String actTitle : rawActivities) {
@@ -47,14 +48,14 @@ public class DashboardController {
                             actTitle.trim(),
                             "Description par défaut",
                             0.0,
-                            "2025-01-01",
+                            dateDebut + "T10:00:00", //format LocalDateTime requis pour le backend
                             "To Do"
                     );
                     activityList.add(act);
                 }
             }
 
-            String dateDebut = (dateInput.getValue() != null) ? dateInput.getValue().toString() : "2025-01-01";
+            
             String dateFin = dateDebut; // TODO: Ajouter un champ date fin plus tard
             Double budget = Double.parseDouble(priceInput.getText());
 

--- a/frontend/src/main/resources/fxml/dashboard.fxml
+++ b/frontend/src/main/resources/fxml/dashboard.fxml
@@ -22,6 +22,10 @@
 
             <ListView fx:id="tripList" VBox.vgrow="ALWAYS" styleClass="dark-list"/>
 
+            <Label text="Activités du voyage" styleClass="subtitle-label"/>
+
+            <ListView fx:id="activityDisplayList" VBox.vgrow="ALWAYS" styleClass="dark-list"/>
+
             <Button text="Actualiser" onAction="#onRefresh" maxWidth="Infinity" styleClass="button, btn-secondary"/>
         </VBox>
     </left>


### PR DESCRIPTION
Problème : Il était impossible de créer de nouveaux voyages.

- Le format LocalDateTime était requis pour le backend (DashboardController.java)
- Le contrôleur essayait d'utiliser activityDisplayList mais le fichier FXML n'avait pas de ListView.

L'ajout de voyages devrait fonctionner dès à présent.

- 
Closes #36 